### PR TITLE
Added a missing "t" to "matches"

### DIFF
--- a/doc_src/en/Menus_Options.xml
+++ b/doc_src/en/Menus_Options.xml
@@ -53,7 +53,7 @@
 		</itemizedlist>
 
         <para>Allows you to activate or deactivate fuzzy matching for glossary
-        maches.</para>
+        matches.</para>
 
 		<para>See the <link linkend="dialogs.preferences.glossary"
 		endterm="dialogs.preferences.glossary.title"/> preferences for
@@ -72,7 +72,7 @@
 		</itemizedlist>
 
         <para>Allows you to activate or deactivate fuzzy matching for dictionary
-        maches.</para>
+        matches.</para>
 
 		<para>See the <link linkend="dialogs.preferences.dictionary"
 		endterm="dialogs.preferences.dictionary.title"/> preferences for


### PR DESCRIPTION
« glossary maches »
« dictionary maches »
--> matches